### PR TITLE
Add Erlang 18.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: erlang
 otp_release:
+  - 18.2
   - 17.1
   - 17.0
   - R16B03

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R15|R16|17"}.
+{require_otp_vsn, "R15|R16|17|18"}.
 
 {eunit_opts, [verbose]}.
 


### PR DESCRIPTION
Actualy, to make jch-erl compile on Erlang 18.